### PR TITLE
Feat/user update

### DIFF
--- a/app/db/models/user.py
+++ b/app/db/models/user.py
@@ -10,12 +10,14 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(100), nullable=False)
+    name = Column(String(100), nullable=True)
     email = Column(String(100), unique=True, index=True, nullable=False)
-    hashed_password = Column(String(128), nullable=False)  # stocke hashed password
+    hashed_password = Column(String(128), nullable=False)
     role = Column(String(50), default="user")
     image_url = Column(String(500), nullable=True)
-    consent = Column(Integer, default=1)  # 1  =autorise collecte, 0 = local
+    consent = Column(Integer, default=1)
+    age = Column(Integer, default=0)
+    gender = Column(String(10), nullable=True)
     created_at = Column(DateTime, default=datetime.now(timezone.utc))
     updated_at = Column(
         DateTime,

--- a/app/schemas/user_dto.py
+++ b/app/schemas/user_dto.py
@@ -28,8 +28,8 @@ class UserResponse(BaseModel):
     email: EmailStr
     role: Optional[str]
     consent: int
-    age: int
-    gender: str
+    age: Optional[int]
+    gender: Optional[str]
     created_at: datetime
     updated_at: datetime
 

--- a/app/schemas/user_dto.py
+++ b/app/schemas/user_dto.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 
 class UserCreateDTO(BaseModel):
-    name: str = Field(..., max_length=100)
+    name: Optional[str] = Field(None, max_length=100)
     email: EmailStr
     password: str
     role: Optional[str] = None
@@ -18,6 +18,8 @@ class UserUpdateDTO(BaseModel):
     role: Optional[str] = None
     password: Optional[str] = None
     consent: Optional[int] = 1
+    age: Optional[int] = 0
+    gender: Optional[str] = None
 
 
 class UserResponse(BaseModel):
@@ -26,6 +28,8 @@ class UserResponse(BaseModel):
     email: EmailStr
     role: Optional[str]
     consent: int
+    age: int
+    gender: str
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
This pull request introduces updates to the `User` model and its associated DTOs (`UserCreateDTO`, `UserUpdateDTO`, and `UserResponse`) to enhance flexibility and add new attributes. The most important changes include making the `name` field optional, adding `age` and `gender` attributes, and aligning the schema definitions with the updated database model.

### Updates to `User` model:

* [`app/db/models/user.py`](diffhunk://#diff-3762bd3f32c3c40bf575b1d3931c1fe4a635ebed37cdf5a5ffa6a84c13c961c0L13-R20): Made the `name` field nullable, added `age` and `gender` attributes with default values, and removed comments for cleaner code.

### Updates to DTOs:

* [`app/schemas/user_dto.py`](diffhunk://#diff-2bd132e13de592d15588354ffc0d494de9774bf9e56fb3c1849d186e8df3a94fL7-R7): Modified `UserCreateDTO` to make the `name` field optional.
* [`app/schemas/user_dto.py`](diffhunk://#diff-2bd132e13de592d15588354ffc0d494de9774bf9e56fb3c1849d186e8df3a94fR21-R22): Updated `UserUpdateDTO` to include new optional fields `age` and `gender`.
* [`app/schemas/user_dto.py`](diffhunk://#diff-2bd132e13de592d15588354ffc0d494de9774bf9e56fb3c1849d186e8df3a94fR31-R32): Updated `UserResponse` to include `age` and `gender` attributes in the response schema.